### PR TITLE
multiple GPUs UI improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(CUDAToolkit)
 add_definitions(-DNAPI_VERSION=7)
 
 include_directories(${CMAKE_JS_INC})
+include_directories(node_modules/node-api-headers/include/)
+include_directories(node_modules/node-addon-api/)
 
 set(SOURCE_FILES src/cpp/GpuAddon.cpp
   src/cpp/windows/amd/AmdGpuMetrics.cpp

--- a/src/actions/gpu-mem.ts
+++ b/src/actions/gpu-mem.ts
@@ -96,7 +96,7 @@ export class GpuMemoryUsage extends SingletonAction<GpuMemoryUsageSettings> {
   ): Promise<void> | void {
     const gpus = this.devices.map((gpu: Gpu) => {
       return {
-        title: gpu.name,
+        title: "#" + gpu.index + " " + gpu.name,
         value: gpu.deviceId,
       };
     });

--- a/src/actions/gpu-temp.ts
+++ b/src/actions/gpu-temp.ts
@@ -69,7 +69,7 @@ export class GpuTemp extends SingletonAction<GpuTempSettings> {
   ): Promise<void> | void {
     const gpus = this.devices.map((gpu: Gpu) => {
       return {
-        title: gpu.name,
+        title: "#" + gpu.index + " " + gpu.name,
         value: gpu.deviceId,
       };
     });

--- a/src/actions/gpu-usage.ts
+++ b/src/actions/gpu-usage.ts
@@ -57,7 +57,7 @@ export class GpuUsage extends SingletonAction<GpuUsageSettings> {
   ): Promise<void> | void {
     const gpus = this.devices.map((gpu: Gpu) => {
       return {
-        title: gpu.name,
+        title: "#" + gpu.index + " " + gpu.name,
         value: gpu.deviceId,
       };
     });


### PR DESCRIPTION
Wanted to create an issue since old version that's in marketplace doesn't support multiple GPUs, but it seems the new version does. Any idea when new version will be published?

Some minor UI improvements, in case of multiple GPUs especially if you have the same one multiple times it can be confusing.

Added just `"#" + gpu.index` prefix to title.

Small change in CMakeLists.txt so that CLion would show me less red.

Tested locally on Win11 with 2x RTX 4070:

![image](https://github.com/user-attachments/assets/d6744339-53be-4c61-9b87-fa4e0ba87066)


